### PR TITLE
lオプションを受け取った際にファイル、ディレクトリの詳細情報を表示するよう変更

### DIFF
--- a/04.ls/my_ls
+++ b/04.ls/my_ls
@@ -2,12 +2,13 @@
 # frozen_string_literal: true
 
 require 'optparse'
+require 'etc'
 
 COLUMN = 3
 
 def main
   params = options
-  resources = target_resources(params)
+  resources = target_resources
   sorted_resources = sort_resources(resources)
   if params[:l]
     formatted_resources = format_resources_for_l(sorted_resources)
@@ -26,7 +27,7 @@ def options
   params
 end
 
-def target_resources(params)
+def target_resources
   resources = Dir.children('.')
   resources.reject { |file| file.start_with?('.') }
 end
@@ -47,27 +48,65 @@ def format_resources(resources)
 end
 
 def format_resources_for_l(resources)
-  files = []
   formatted_resources = []
-  resources.each { |resource| files << File.new(File.absolute_path(resource)) }
-  files.each do |file|
-    permission = file
-    hard_link_count = file
-    user = file
-    group = file
-    size = file
-    stamp = file
-    formatted_resources << [permission, hard_link_count, user, group, size, stamp]
+  files = target_files(resources)
+  max_nlink = files.map { |file| file[:nlink] }.max.to_s.size
+  max_user = files.map { |file| file[:user] }.map(&:size).max
+  max_group = files.map { |file| file[:group] }.map(&:size).max
+  max_file_size = files.map { |file| file[:file_size] }.max.to_s.size
+  files.map do |file|
+    file[:nlink] = file[:nlink].to_s.rjust(max_nlink, ' ')
+    file[:user] = file[:user].ljust(max_user, ' ')
+    file[:group] = file[:group].ljust(max_group, ' ')
+    file[:file_size] = file[:file_size].to_s.rjust(max_file_size, ' ')
+    formatted_resources << file
   end
-  # ここでpermission以降の要素の縦列の長さを揃える処理が必要
-
   formatted_resources
 end
 
-def to_permissions(binary)
-  binary.chars.each_slice(3).each do |aaa|
-    
+def target_files(resources)
+  files = []
+  resources.each do |resource|
+    files << target_file_info(resource)
   end
+  files
+end
+
+def target_file_info(resource)
+  file_stat = File.new(File.absolute_path(resource)).stat
+  blksize = file_stat.blocks / 2 # OS側では1ブロックサイズ1024bytes, Ruby側では512bytesで計算されるため補正
+  file_type = target_file_type(file_stat.ftype)
+  permission = target_permission(file_stat.mode)
+  file_permission = file_type + permission
+  nlink = file_stat.nlink
+  user = Etc.getpwuid(file_stat.uid).name
+  group = Etc.getgrgid(file_stat.gid).name
+  file_size = file_stat.size
+  mtime = file_stat.mtime.strftime('%b %e %R')
+  { blksize:, file_permission:, nlink:, user:, group:, file_size:, mtime:, resource: }
+end
+
+def target_file_type(ftype)
+  {
+    'file' => '-',
+    'directory' => 'd',
+    'characterSpecial' => 'c',
+    'blockSpecial' => 'b',
+    'fifo' => 'p',
+    'link' => 'l',
+    'socket' => 's'
+  }[ftype]
+end
+
+def target_permission(mode)
+  binary = mode.to_s(2)[-9..]
+  permission_attributes = []
+  binary.chars.each_slice(3) do |attributes|
+    permission_attributes << (attributes[0] == '1' ? 'r' : '-')
+    permission_attributes << (attributes[1] == '1' ? 'w' : '-')
+    permission_attributes << (attributes[2] == '1' ? 'x' : '-')
+  end
+  permission_attributes.join
 end
 
 def display_resources(resources)
@@ -77,6 +116,12 @@ def display_resources(resources)
 end
 
 def display_resources_for_l(resources)
+  total_blksize = resources.map { |resource| resource[:blksize] }.sum
+  resources.map { |resource| resource.delete(:blksize) }
+  puts "total #{total_blksize}"
+  resources.each do |resource|
+    puts resource.values.join(' ')
+  end
 end
 
 main

--- a/04.ls/my_ls
+++ b/04.ls/my_ls
@@ -7,29 +7,32 @@ COLUMN = 3
 
 def main
   params = options
-  resources = target_resources
-  sorted_resources = sort_resources(resources, params)
-  formatted_resources = format_resources(sorted_resources)
-  display_resources(formatted_resources)
+  resources = target_resources(params)
+  sorted_resources = sort_resources(resources)
+  if params[:l]
+    formatted_resources = format_resources_for_l(sorted_resources)
+    display_resources_for_l(formatted_resources)
+  else
+    formatted_resources = format_resources(sorted_resources)
+    display_resources(formatted_resources)
+  end
 end
 
 def options
   opt = OptionParser.new
   params = {}
-  opt.on('-r') { |v| params[:r] = v }
+  opt.on('-l') { |v| params[:l] = v }
   opt.parse!(ARGV)
   params
 end
 
-def target_resources
-  resources = Dir.entries('.')
+def target_resources(params)
+  resources = Dir.children('.')
   resources.reject { |file| file.start_with?('.') }
 end
 
-def sort_resources(resources, params)
-  resources = resources.sort_by { |resource| resource.downcase.gsub(/[.\-_]/, '') }
-  resources = resources.reverse if params[:r]
-  resources
+def sort_resources(resources)
+  resources.sort_by { |resource| resource.downcase.gsub(/[.\-_]/, '') }
 end
 
 def format_resources(resources)
@@ -43,10 +46,37 @@ def format_resources(resources)
   alligned_resources.transpose
 end
 
+def format_resources_for_l(resources)
+  files = []
+  formatted_resources = []
+  resources.each { |resource| files << File.new(File.absolute_path(resource)) }
+  files.each do |file|
+    permission = file
+    hard_link_count = file
+    user = file
+    group = file
+    size = file
+    stamp = file
+    formatted_resources << [permission, hard_link_count, user, group, size, stamp]
+  end
+  # ここでpermission以降の要素の縦列の長さを揃える処理が必要
+
+  formatted_resources
+end
+
+def to_permissions(binary)
+  binary.chars.each_slice(3).each do |aaa|
+    
+  end
+end
+
 def display_resources(resources)
   resources.each do |column|
     puts column.compact.join
   end
+end
+
+def display_resources_for_l(resources)
 end
 
 main

--- a/04.ls/my_ls
+++ b/04.ls/my_ls
@@ -100,9 +100,9 @@ end
 
 def display_resources_for_l(resources)
   total_blksize = resources.sum { |resource| resource[:blksize] }
-  resources.map { |resource| resource.delete(:blksize) }
   puts "total #{total_blksize}"
   resources.each do |resource|
+    resource.delete(:blksize)
     puts resource.values.join(' ')
   end
 end

--- a/04.ls/my_ls
+++ b/04.ls/my_ls
@@ -48,28 +48,18 @@ def format_resources(resources)
 end
 
 def format_resources_for_l(resources)
-  formatted_resources = []
-  files = target_files(resources)
+  files = resources.map { |resource| target_file_info(resource) }
   max_nlink = files.map { |file| file[:nlink] }.max.to_s.size
-  max_user = files.map { |file| file[:user] }.map(&:size).max
-  max_group = files.map { |file| file[:group] }.map(&:size).max
+  max_user = files.map { |file| file[:user].size }.max
+  max_group = files.map { |file| file[:group].size }.max
   max_file_size = files.map { |file| file[:file_size] }.max.to_s.size
   files.map do |file|
     file[:nlink] = file[:nlink].to_s.rjust(max_nlink, ' ')
     file[:user] = file[:user].ljust(max_user, ' ')
     file[:group] = file[:group].ljust(max_group, ' ')
     file[:file_size] = file[:file_size].to_s.rjust(max_file_size, ' ')
-    formatted_resources << file
+    file
   end
-  formatted_resources
-end
-
-def target_files(resources)
-  files = []
-  resources.each do |resource|
-    files << target_file_info(resource)
-  end
-  files
 end
 
 def target_file_info(resource)
@@ -100,13 +90,9 @@ end
 
 def target_permission(mode)
   binary = mode.to_s(2)[-9..]
-  permission_attributes = []
-  binary.chars.each_slice(3) do |attributes|
-    permission_attributes << (attributes[0] == '1' ? 'r' : '-')
-    permission_attributes << (attributes[1] == '1' ? 'w' : '-')
-    permission_attributes << (attributes[2] == '1' ? 'x' : '-')
-  end
-  permission_attributes.join
+  binary.chars.each_slice(3).map do |r, w, x|
+    "#{r == '1' ? 'r' : '-'}#{w == '1' ? 'w' : '-'}#{x == '1' ? 'x' : '-'}"
+  end.join
 end
 
 def display_resources(resources)
@@ -116,7 +102,7 @@ def display_resources(resources)
 end
 
 def display_resources_for_l(resources)
-  total_blksize = resources.map { |resource| resource[:blksize] }.sum
+  total_blksize = resources.sum { |resource| resource[:blksize] }
   resources.map { |resource| resource.delete(:blksize) }
   puts "total #{total_blksize}"
   resources.each do |resource|

--- a/04.ls/my_ls
+++ b/04.ls/my_ls
@@ -5,6 +5,15 @@ require 'optparse'
 require 'etc'
 
 COLUMN = 3
+FILE_TYPE = {
+  'file' => '-',
+  'directory' => 'd',
+  'characterSpecial' => 'c',
+  'blockSpecial' => 'b',
+  'fifo' => 'p',
+  'link' => 'l',
+  'socket' => 's'
+}.freeze
 
 def main
   params = options
@@ -65,7 +74,7 @@ end
 def target_file_info(resource)
   file_stat = File.new(File.absolute_path(resource)).stat
   blksize = file_stat.blocks / 2 # OS側では1ブロックサイズ1024bytes, Ruby側では512bytesで計算されるため補正
-  file_type = target_file_type(file_stat.ftype)
+  file_type = FILE_TYPE[file_stat.ftype]
   permission = target_permission(file_stat.mode)
   file_permission = file_type + permission
   nlink = file_stat.nlink
@@ -74,18 +83,6 @@ def target_file_info(resource)
   file_size = file_stat.size
   mtime = file_stat.mtime.strftime('%b %e %R')
   { blksize:, file_permission:, nlink:, user:, group:, file_size:, mtime:, resource: }
-end
-
-def target_file_type(ftype)
-  {
-    'file' => '-',
-    'directory' => 'd',
-    'characterSpecial' => 'c',
-    'blockSpecial' => 'b',
-    'fifo' => 'p',
-    'link' => 'l',
-    'socket' => 's'
-  }[ftype]
 end
 
 def target_permission(mode)


### PR DESCRIPTION
今回のlsコマンドlオプション実装プラクティスは難しかったです💦
メソッドの命名、分割の粒度等あまり自信がないので、ご指摘あればお願いいたします。
特にformat_resources_for_lメソッドについては、
- 処理が多い
- max_xxx変数でのメソッドチェーンが長くなっている
ことについて気にはなっているのですが、より良い方法が思い浮かばなかったためアドバイスあればいただきたいです🙏